### PR TITLE
fix paths to make compilation work

### DIFF
--- a/Emakefile
+++ b/Emakefile
@@ -1,3 +1,3 @@
-{'../../ejabberd-dev/trunk/src/gen_mod',
-	[{outdir, "../../ejabberd-dev/trunk/ebin"},{i,"../../ejabberd-dev/trunk/include"}]}.
-{'src/*',     [{outdir, "ebin"},{i,"../../ejabberd-dev/trunk/include"}]}.
+{'../ejabberd-dev/trunk/src/gen_mod',
+	[{outdir, "../ejabberd-dev/trunk/ebin"},{i,"../ejabberd-dev/trunk/include"}]}.
+{'src/*',     [{outdir, "ebin"},{i,"../ejabberd-dev/trunk/include"}]}.

--- a/build.bat
+++ b/build.bat
@@ -1,1 +1,1 @@
-erl -pa ../../ejabberd-dev/trunk/ebin -pa ebin -make
+erl -pa ../ejabberd-dev/trunk/ebin -pa ebin -make

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-erl -pa ../../ejabberd-dev/trunk/ebin -pz ebin -make
+erl -pa ../ejabberd-dev/trunk/ebin -pz ebin -make


### PR DESCRIPTION
If following the instructions from README.md build files would throw errors because the actual directory structure required is not met. This patch assumes mod_log_chat_mysql5 is a direct child directory of the ejabberd-modules checkout.
